### PR TITLE
Remove hardcoded version of `PySide`, and other stuff

### DIFF
--- a/ExportOpenEMSDialog.py
+++ b/ExportOpenEMSDialog.py
@@ -1,5 +1,5 @@
-from PySide2 import QtGui, QtCore, QtWidgets
-from PySide2.QtCore import Slot
+from PySide6 import QtGui, QtCore, QtWidgets
+from PySide6.QtCore import Slot
 import os, sys
 import re
 import random
@@ -109,8 +109,8 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		elif event.type() == QtCore.QEvent.WindowActivate and self.cadInterfaceType == "Blender":
 			self.blenderWindowActivatedHandler()
 		return super(ExportOpenEMSDialog, self).eventFilter(object, event)
-		
-	def __init__(self):		
+
+	def __init__(self):
 		QtCore.QObject.__init__(self)
 
 		self.APP_DIR = APP_DIR
@@ -135,7 +135,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.form = self.cadHelpers.loadUI(path_to_ui, self)
 		# self.form.finished.connect(self.finished) # QDialog event
 		self.form.installEventFilter(self)
-		
+
 		# add a statusBar widget (comment to revert to QMessageBox if there are any problems)
 		self.statusBar = QtWidgets.QStatusBar()
 		self.statusBar.setStyleSheet("QStatusBar{border-top: 1px outset grey;}")
@@ -188,7 +188,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 		self.form.moveLeftButton.clicked.connect(self.onMoveLeft)
 		self.form.moveRightButton.clicked.connect(self.onMoveRight)
-		
+
 		#########################################################################################################
 		#	Left Column - FreeCAD objects list
 		#########################################################################################################
@@ -196,16 +196,16 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.internalObjectNameLabelList = {}
 
 		self.initLeftColumnTopLevelItems()
-		self.form.objectAssignmentLeftTreeWidget.itemDoubleClicked.connect(self.objectAssignmentLeftTreeWidgetItemDoubleClicked)	
+		self.form.objectAssignmentLeftTreeWidget.itemDoubleClicked.connect(self.objectAssignmentLeftTreeWidgetItemDoubleClicked)
 		self.form.objectAssignmentLeftTreeWidget.itemSelectionChanged.connect(self.objectAssignmentLeftTreeWidgetItemSelectionChanged)
 
 		#########################################################################################################
 		#	RIGHT COLUMN - Simulation Object Assignment
 		#########################################################################################################
-		
+
 		self.form.objectAssignmentRightTreeWidget.itemSelectionChanged.connect(self.objectAssignmentRightTreeWidgetItemSelectionChanged)
 
-		self.form.objectAssignmentRightTreeWidget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)  
+		self.form.objectAssignmentRightTreeWidget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
 		self.form.objectAssignmentRightTreeWidget.customContextMenuRequested.connect(self.objectAssignmentRightTreeWidgetContextClicked)
 		self.form.objectAssignmentRightTreeWidget.itemDoubleClicked.connect(self.objectAssignmentRightTreeWidgetItemDoubleClicked)
 
@@ -252,23 +252,23 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.form.smoothMeshRadioButton.clicked.connect(self.smoothMeshRadioButtonClicked)
 
 		# Handle function for MATERIAL RADIO BUTTONS
-		self.form.materialUserDefinedRadioButton.toggled.connect(self.materialUserDeinedRadioButtonToggled)	
+		self.form.materialUserDefinedRadioButton.toggled.connect(self.materialUserDeinedRadioButtonToggled)
 		self.form.materialConductingSheetRadioButton.toggled.connect(self.materialConductingSheetRadioButtonToggled)
 
 		#
 		# Clicked on "Generate OpenEMS Script"
-		#		
+		#
 		self.form.generateOpenEMSScriptButton.clicked.connect(self.generateOpenEMSScriptButtonClicked)
 
 		#
 		# Clicked on BUTTONS FOR OBJECT PRIORITIES
-		#		
+		#
 		self.form.moveupPriorityButton.clicked.connect(self.moveupPriorityButtonClicked)
 		self.form.movedownPriorityButton.clicked.connect(self.movedownPriorityButtonClicked)
 
 		#
 		# Clicked on BUTTONS FOR MESH PRIORITIES
-		#		
+		#
 		self.form.moveupMeshPriorityButton.clicked.connect(self.moveupPriorityMeshButtonClicked)
 		self.form.movedownMeshPriorityButton.clicked.connect(self.movedownPriorityMeshButtonClicked)
 
@@ -286,7 +286,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		#	- button "Display gridlines...."
 		#	- button "Create userdef..."
 		#	- select rectangular or cylindrical grid
-		#		
+		#
 		self.form.createUserdefGridLinesFromCurrentButton.clicked.connect(self.createUserdefGridLinesFromCurrentButtonClicked)
 		self.form.displayXYGridLinesInModelButton.clicked.connect(self.displayXYGridLinesInModelButtonClicked)
 		self.form.gridRectangularRadio.toggled.connect(self.gridCoordsTypeChoosed)
@@ -338,12 +338,12 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 		#
 		# Material, Grid, Excitation, ... item changed handler functions.
-		#		
-		self.form.materialSettingsTreeView.currentItemChanged.connect(self.materialTreeWidgetItemChanged)	
-		self.form.excitationSettingsTreeView.currentItemChanged.connect(self.excitationTreeWidgetItemChanged)	
-		self.form.gridSettingsTreeView.currentItemChanged.connect(self.gridTreeWidgetItemChanged)	
+		#
+		self.form.materialSettingsTreeView.currentItemChanged.connect(self.materialTreeWidgetItemChanged)
+		self.form.excitationSettingsTreeView.currentItemChanged.connect(self.excitationTreeWidgetItemChanged)
+		self.form.gridSettingsTreeView.currentItemChanged.connect(self.gridTreeWidgetItemChanged)
 		self.form.portSettingsTreeView.currentItemChanged.connect(self.portTreeWidgetItemChanged)
-		self.form.lumpedPartTreeView.currentItemChanged.connect(self.lumpedPartTreeWidgetItemChanged)	
+		self.form.lumpedPartTreeView.currentItemChanged.connect(self.lumpedPartTreeWidgetItemChanged)
 		self.form.probeSettingsTreeView.currentItemChanged.connect(self.probeTreeWidgetItemChanged)
 
 		#
@@ -428,11 +428,11 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		#
 		self.form.objectAssignmentFilterLeft.returnPressed.connect(self.applyObjectAssignmentFilter)
 
-		# MinDecrement changed 
+		# MinDecrement changed
 		self.form.simParamsMinDecrement.valueChanged.connect(self.simParamsMinDecrementValueChanged)
-		
+
 		### Other Initialization
-		
+
 		# initialize dB preview label with converted value
 		self.simParamsMinDecrementValueChanged(self.form.simParamsMinDecrement.value())
 
@@ -531,8 +531,8 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		# A new object has been created. Only the list of available objects needs to be updated.
 		filterStr = self.form.objectAssignmentFilterLeft.text()
 		self.initLeftColumnTopLevelItems(filterStr)
-		
-	
+
+
 	def freecadObjectChanged(self, obj, prop, enableReInitLeftColumn=True):
 		print("freecadObjectChanged :{} ('{}') property changed: {}".format(obj.FullName, obj.Label, prop))
 
@@ -573,9 +573,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 				self.initLeftColumnTopLevelItems(filterStr)
 
 	def freecadBeforeObjectDeleted(self,obj):
-		# event is generated before object is being removed, so observing instances have to 
+		# event is generated before object is being removed, so observing instances have to
 		# (TODO) un-list the object without drawing upon the FreeCAD objects list, and
-		# (TODO) propagate changes to prevent corruption. 
+		# (TODO) propagate changes to prevent corruption.
 		#    Simple approach: delete dependent entries.
 		#    Advanced: remember and gray out deleted objects to allow settings to be restored when
 		#    the user brings the object back with Redo.
@@ -688,7 +688,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		if newValue == 0:
 			s = '( -inf dB )'
 		else:
-			s = '( ' + str(np.round(10 * np.log10(newValue), decimals=2)) + ' dB )' 
+			s = '( ' + str(np.round(10 * np.log10(newValue), decimals=2)) + ' dB )'
 		self.form.simParamsMinDecrementdBLabel.setText(s)
 
 	def BCxminCurrentIndexChanged(self, index):
@@ -730,14 +730,14 @@ class ExportOpenEMSDialog(QtCore.QObject):
 				gridLineDirection = abs(gridLine.End - gridLine.Start)
 				if (gridLineDirection[0] > 0):
 					gridLineListX.append(gridLine)
-		
+
 
 		print("Discovered " + str(len(gridLineList)) + " gridlines in model.")
 		print("--> End creating user defined grid from 3D model.")
 		"""
 		self.guiHelpers.displayMessage("createUserdefGridLinesFromCurrentButtonClicked")
 
-	def displayXYGridLinesInModelButtonClicked(self):        
+	def displayXYGridLinesInModelButtonClicked(self):
 		print('displayXYGridLinesInModelButtonClicked: start draw whole XY grid for each object')
 
 		gridCategory = self.form.objectAssignmentRightTreeWidget.findItems("Grid", QtCore.Qt.MatchFixedString)[0]
@@ -784,7 +784,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 	def updateObjectAssignmentRightTreeWidgetItemData(self, groupName, itemName, data):
 		updatedItems = self.form.objectAssignmentRightTreeWidget.findItems(
-			itemName, 
+			itemName,
 			QtCore.Qt.MatchExactly | QtCore.Qt.MatchFlag.MatchRecursive
 			)
 
@@ -880,7 +880,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 				self.form.objectAssignmentRightTreeWidget.expandAll()
 			if menu_action == actioN_collapse:
 				self.form.objectAssignmentRightTreeWidget.collapseAll()
-				
+
 	#
 	#	Handler for DOUBLE CLICK on grid item in FreeCAD objects list
 	#
@@ -919,7 +919,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			return
 
 		bbCoords = gridObj[0].Shape.BoundBox
-	
+
 		print("Start drawing aux grid for: " + currSetting.name)
 		print("Enabled coords: " + str(currSetting.xenabled) + " " + str(currSetting.yenabled) + " " + str(currSetting.zenabled))
 
@@ -958,7 +958,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							zlines = np.array([(bbCoords.ZMin + bbCoords.ZMax)/2])
 						else:
 							zlines = np.linspace(bbCoords.ZMin, bbCoords.ZMax, int(currSetting.getXYZ(refUnit)['z']))
-							
+
 						#collecting Z coordinates where grid layers will be drawn
 						for zGridLine in zlines:
 							zAuxGridCoordList.append(zGridLine)
@@ -967,26 +967,26 @@ class ExportOpenEMSDialog(QtCore.QObject):
 				print(zAuxGridCoordList)
 				if len(zAuxGridCoordList) == 0:
 					zAuxGridCoordList.append(bbCoords.ZMax)
-	
+
 				for zAuxGridCoord in zAuxGridCoordList:
-					
+
 					bbPointsVectors = [self.cadHelpers.Vector(bbCoords.YMin, bbCoords.XMin, 0), self.cadHelpers.Vector(bbCoords.YMin, bbCoords.XMax, 0), self.cadHelpers.Vector(bbCoords.YMax, bbCoords.XMin, 0), self.cadHelpers.Vector(bbCoords.YMax, bbCoords.XMax, 0)]
 					angle1 = math.atan2(bbCoords.YMin, bbCoords.XMin) + 2*math.pi % (2*math.pi)
 					angle2 = math.atan2(bbCoords.YMin, bbCoords.XMax) + 2*math.pi % (2*math.pi)
 					angle3 = math.atan2(bbCoords.YMax, bbCoords.XMin) + 2*math.pi % (2*math.pi)
 					angle4 = math.atan2(bbCoords.YMax, bbCoords.XMax) + 2*math.pi % (2*math.pi)
-					
+
 					minAngle = min([angle1, angle2, angle3, angle4])
-					maxAngle = max([angle1, angle2, angle3, angle4])						
+					maxAngle = max([angle1, angle2, angle3, angle4])
 					radius = max([math.sqrt(modelMinX**2 + modelMinY**2), math.sqrt(modelMaxX**2 + modelMaxY**2)])
 
 					print("Calculate ylines for cylindrical coords.")
 					print("minAngle: " + str(minAngle))
 					print("maxAngle: " + str(maxAngle))
-					print("radius: " + str(radius))						
+					print("radius: " + str(radius))
 
 					#DRAW X LINES auxiliary grid in 3D view
-					if (currSetting.xenabled):						
+					if (currSetting.xenabled):
 						a = np.array([angle1, angle2, angle3, angle4])
 						indicesMin = a.argmin()
 						indicesMax = a.argmax()
@@ -1000,17 +1000,17 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							xlines = np.array([(minRadius + maxRadius)/2])
 						else:
 							xlines = np.linspace(minRadius, maxRadius, int(currSetting.getXYZ(refUnit)['x']))
-							
+
 						for xGridLine in xlines:
 							self.cadHelpers.drawDraftCircle("auxGridLine", self.cadHelpers.Vector(0,0,zAuxGridCoord), xGridLine)
 
 					#DRAW Y LINES auxiliary grid in 3D view
-					if (currSetting.yenabled):												
+					if (currSetting.yenabled):
 						if float(currSetting.getXYZ(refUnit)['y']) == 1:
 							ylines = np.array([(minAngle, maxAngle)/2])
 						else:
 							ylines = np.linspace(minAngle, maxAngle, int(currSetting.getXYZ(refUnit)['y']))
-							
+
 						print(ylines)
 
 						for yGridLine in ylines:
@@ -1025,7 +1025,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			print("Drawing GRID in Z axis.")
 
 			if (currSetting.getType() == 'Fixed Distance'):
-	
+
 				#here adding Z coordinates for which grid will be drawn so grid will be drawn in XY plane, so here are collected just Z coords for which it will be drawn
 				zAuxGridCoordList = []
 				if (currSetting.zenabled):
@@ -1035,7 +1035,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							zAuxGridCoordList.append(zGridLine)
 				if len(zAuxGridCoordList) == 0:
 					zAuxGridCoordList.append(bbCoords.ZMax)
-	
+
 				for zAuxGridCoord in zAuxGridCoordList:
 					#DRAW X LINES auxiliary grid in 3D view
 					if (currSetting.xenabled):
@@ -1044,7 +1044,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							for xGridLine in xlines:
 								#self.cadHelpers.drawDraftLine("auxGridLine", [xGridLine, bbCoords.YMin, zAuxGridCoord], [xGridLine, bbCoords.YMax, zAuxGridCoord])
 								self.cadHelpers.drawDraftLine("auxGridLine", [xGridLine, modelMinY, zAuxGridCoord], [xGridLine, modelMaxY, zAuxGridCoord])
-		
+
 					#DRAW Y LINES auxiliary grid in 3D view
 					if (currSetting.yenabled):
 						if float(currSetting.getXYZ(refUnit)['y']) != 0:
@@ -1052,9 +1052,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							for yGridLine in ylines:
 								#self.cadHelpers.drawDraftLine("auxGridLine", [bbCoords.XMin, yGridLine, zAuxGridCoord], [bbCoords.XMax, yGridLine, zAuxGridCoord])
 								self.cadHelpers.drawDraftLine("auxGridLine", [modelMinX, yGridLine, zAuxGridCoord], [modelMaxX, yGridLine, zAuxGridCoord])
-	
+
 			elif (currSetting.getType() == 'Fixed Count'):
-	
+
 	            #collecting Z coordinates where grid will be drawn, grid will be drawn in XY plane
 				zAuxGridCoordList = []
 				if (currSetting.zenabled):
@@ -1063,13 +1063,13 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							zlines = np.arange(bbCoords.ZMin, bbCoords.ZMax, int(currSetting.getXYZ(refUnit)['z']))
 						else:
 							zlines = np.array([(bbCoords.ZMin + bbCoords.ZMax)/2])
-							
+
 						#collecting Z coordinates where grid layers will be drawn
 						for zGridLine in zlines:
 							zAuxGridCoordList.append(zGridLine)
 				if len(zAuxGridCoordList) == 0:
 					zAuxGridCoordList.append(bbCoords.ZMax)
-	
+
 				for zAuxGridCoord in zAuxGridCoordList:
 					#DRAW X LINES auxiliary grid in 3D view
 					if (currSetting.xenabled):
@@ -1077,11 +1077,11 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							xlines = np.array([(bbCoords.XMin + bbCoords.XMax)/2])
 						else:
 							xlines = np.linspace(bbCoords.XMin, bbCoords.XMax, int(currSetting.getXYZ(refUnit)['x']))
-							
+
 						for xGridLine in xlines:
 							#self.cadHelpers.drawDraftLine("auxGridLine", [xGridLine, bbCoords.YMin, zAuxGridCoord], [xGridLine, bbCoords.YMax, zAuxGridCoord])
 							self.cadHelpers.drawDraftLine("auxGridLine", [xGridLine, modelMinY, zAuxGridCoord], [xGridLine, modelMaxY, zAuxGridCoord])
-		
+
 					#DRAW Y LINES auxiliary grid in 3D view
 					if (currSetting.yenabled):
 						if float(currSetting.getXYZ(refUnit)['y']) == 1:
@@ -1092,9 +1092,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 						for yGridLine in ylines:
 							#self.cadHelpers.drawDraftLine("auxGridLine", [bbCoords.XMin, yGridLine, zAuxGridCoord], [bbCoords.XMax, yGridLine, zAuxGridCoord])
 							self.cadHelpers.drawDraftLine("auxGridLine", [modelMinX, yGridLine, zAuxGridCoord], [modelMaxX, yGridLine, zAuxGridCoord])
-	
+
 			elif (currSetting.getType() == 'User Defined'):
-				#UNIT FOR MESH										
+				#UNIT FOR MESH
 				genScript += "meshUnit = " + currSetting.getUnitAsScriptLine() + "; % all length in mm\n"
 				genScript += "mesh = " + currSetting.getXYZ(refUnit) + ";\n"
 
@@ -1105,9 +1105,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			#######################################################################################################################################################################
 
 			print("Drawing GRID in X axis.")
-			
+
 			if (currSetting.getType() == 'Fixed Distance'):
-	
+
 				#here adding Z coordinates for which grid will be drawn so grid will be drawn in XY plane, so here are collected just Z coords for which it will be drawn
 				xAuxGridCoordList = []
 				if (currSetting.xenabled):
@@ -1117,7 +1117,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							xAuxGridCoordList.append(xGridLine)
 				if len(xAuxGridCoordList) == 0:
 					xAuxGridCoordList.append(bbCoords.XMax)
-	
+
 				for xAuxGridCoord in xAuxGridCoordList:
 					#DRAW Z LINES auxiliary grid in 3D view
 					if (currSetting.zenabled):
@@ -1125,16 +1125,16 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							zlines = np.arange(bbCoords.ZMin, bbCoords.ZMax, currSetting.getXYZ(refUnit)['z'])
 							for zGridLine in zlines:
 								self.cadHelpers.drawDraftLine("auxGridLine", [xAuxGridCoord, modelMinY, zGridLine], [xAuxGridCoord, modelMaxY, zGridLine])
-		
+
 					#DRAW Y LINES auxiliary grid in 3D view
 					if (currSetting.yenabled):
 						if float(currSetting.getXYZ(refUnit)['y']) != 0:
 							ylines = np.arange(bbCoords.YMin, bbCoords.YMax, currSetting.getXYZ(refUnit)['y'])
 							for yGridLine in ylines:
 								self.cadHelpers.drawDraftLine("auxGridLine", [xAuxGridCoord, yGridLine, modelMinZ], [xAuxGridCoord, yGridLine, modelMaxZ])
-	
+
 			elif (currSetting.getType() == 'Fixed Count'):
-	
+
 	            #collecting Z coordinates where grid will be drawn, grid will be drawn in XY plane
 				xAuxGridCoordList = []
 				if (currSetting.xenabled):
@@ -1143,13 +1143,13 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							xlines = np.array([(bbCoords.XMin + bbCoords.XMax)/2])
 						else:
 							xlines = np.arange(bbCoords.XMin, bbCoords.XMax, int(currSetting.getXYZ(refUnit)['x']))   #collecting Z coordinates where grid layers will be drawn
-							
+
 						for xGridLine in xlines:
 							xAuxGridCoordList.append(xGridLine)
 
 				if len(xAuxGridCoordList) == 0:
 					xAuxGridCoordList.append(bbCoords.XMax)
-	
+
 				for xAuxGridCoord in xAuxGridCoordList:
 					#DRAW X LINES auxiliary grid in 3D view
 					if (currSetting.zenabled):
@@ -1157,25 +1157,25 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							zlines = np.array([(bbCoords.ZMin + bbCoords.ZMax)/2])
 						else:
 							zlines = np.linspace(bbCoords.ZMin, bbCoords.ZMax, int(currSetting.getXYZ(refUnit)['z']))
-						
+
 						for zGridLine in zlines:
 							self.cadHelpers.drawDraftLine("auxGridLine", [xAuxGridCoord, modelMinY, zGridLine], [xAuxGridCoord, modelMaxY, zGridLine])
-		
+
 					#DRAW Y LINES auxiliary grid in 3D view
 					if (currSetting.yenabled):
 						if float(currSetting.getXYZ(refUnit)['y']) == 1:
 							ylines = np.array([(bbCoords.YMin + bbCoords.YMax)/2])
 						else:
 							ylines = np.linspace(bbCoords.YMin, bbCoords.YMax, int(currSetting.getXYZ(refUnit)['y']))
-						
+
 						for yGridLine in ylines:
 								self.cadHelpers.drawDraftLine("auxGridLine", [xAuxGridCoord, yGridLine, modelMinZ], [xAuxGridCoord, yGridLine, modelMaxZ])
-	
+
 			elif (currSetting.getType() == 'User Defined'):
-				#UNIT FOR MESH										
+				#UNIT FOR MESH
 				genScript += "meshUnit = " + currSetting.getUnitAsScriptLine() + "; % all length in mm\n"
 				genScript += "mesh = " + currSetting.getXYZ(refUnit) + ";\n"
-				
+
 		elif (currSetting.coordsType == 'rectangular' and currGridAxis == "y"):
 
 			#######################################################################################################################################################################
@@ -1185,7 +1185,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			print("Drawing GRID in Y axis.")
 
 			if (currSetting.getType() == 'Fixed Distance'):
-	
+
 				#here adding Z coordinates for which grid will be drawn so grid will be drawn in XY plane, so here are collected just Z coords for which it will be drawn
 				yAuxGridCoordList = []
 				if (currSetting.yenabled):
@@ -1195,7 +1195,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							yAuxGridCoordList.append(yGridLine)
 				if len(yAuxGridCoordList) == 0:
 					yAuxGridCoordList.append(bbCoords.YMax)
-	
+
 				for yAuxGridCoord in yAuxGridCoordList:
 					#DRAW Z LINES auxiliary grid in 3D view
 					if (currSetting.zenabled):
@@ -1203,16 +1203,16 @@ class ExportOpenEMSDialog(QtCore.QObject):
 							zlines = np.arange(bbCoords.ZMin, bbCoords.ZMax, currSetting.getXYZ(refUnit)['z'])
 							for zGridLine in zlines:
 								self.cadHelpers.drawDraftLine("auxGridLine", [modelMinX, yAuxGridCoord, zGridLine], [modelMaxX, yAuxGridCoord, zGridLine])
-		
+
 					#DRAW X LINES auxiliary grid in 3D view
 					if (currSetting.xenabled):
 						if float(currSetting.getXYZ(refUnit)['x']) != 0:
 							xlines = np.arange(bbCoords.XMin, bbCoords.XMax, currSetting.getXYZ(refUnit)['x'])
 							for xGridLine in xlines:
 								self.cadHelpers.drawDraftLine("auxGridLine", [xGridLine, yAuxGridCoord, modelMinZ], [xGridLine, yAuxGridCoord, modelMaxZ])
-	
+
 			elif (currSetting.getType() == 'Fixed Count'):
-	
+
 	            #collecting Z coordinates where grid will be drawn, grid will be drawn in XY plane
 				yAuxGridCoordList = []
 				if (currSetting.yenabled):
@@ -1227,7 +1227,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 				if len(yAuxGridCoordList) == 0:
 					yAuxGridCoordList.append(bbCoords.YMax)
-	
+
 				for yAuxGridCoord in yAuxGridCoordList:
 					#DRAW Z LINES auxiliary grid in 3D view
 					if (currSetting.zenabled):
@@ -1238,7 +1238,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 						for zGridLine in zlines:
 							self.cadHelpers.drawDraftLine("auxGridLine", [modelMinX, yAuxGridCoord, zGridLine], [modelMaxX, yAuxGridCoord, zGridLine])
-		
+
 					#DRAW X LINES auxiliary grid in 3D view
 					if (currSetting.xenabled):
 						if float(currSetting.getXYZ(refUnit)['x']) == 1:
@@ -1248,9 +1248,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 						for xGridLine in xlines:
 							self.cadHelpers.drawDraftLine("auxGridLine", [xGridLine, yAuxGridCoord, modelMinZ], [xGridLine, yAuxGridCoord, modelMaxZ])
-	
+
 			elif (currSetting.getType() == 'User Defined'):
-				#UNIT FOR MESH										
+				#UNIT FOR MESH
 				genScript += "meshUnit = " + currSetting.getUnitAsScriptLine() + "; % all length in mm\n"
 				genScript += "mesh = " + currSetting.getXYZ(refUnit) + ";\n"
 
@@ -1261,7 +1261,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 	#######################################################################################################################################################################
   	# END GRID DRAWING
 	#######################################################################################################################################################################
-	
+
 	def initLeftColumnTopLevelItems(self, filterStr = ""):
 		self.form.objectAssignmentLeftTreeWidget.clear()
 
@@ -1277,7 +1277,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			topItem.setData(0, QtCore.Qt.UserRole, itemData)
 			if (i.Name.find("Sketch") > -1):
 				topItem.setIcon(0, QtGui.QIcon(os.path.join(self.APP_DIR, "img", "wire.svg")))
-			elif (i.Name.find("Discretized_Edge") > -1): 
+			elif (i.Name.find("Discretized_Edge") > -1):
 				topItem.setIcon(0, QtGui.QIcon(os.path.join(self.APP_DIR, "img", "curve.svg")))
 			else:
 				topItem.setIcon(0, QtGui.QIcon(os.path.join(self.APP_DIR, "img", "object.svg")))
@@ -1772,12 +1772,12 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.guiHelpers.displayMessage("Script to display far field generated.")
 
 	# GRID SETTINGS
-	#   _____ _____  _____ _____     _____ ______ _______ _______ _____ _   _  _____  _____ 
+	#   _____ _____  _____ _____     _____ ______ _______ _______ _____ _   _  _____  _____
 	#  / ____|  __ \|_   _|  __ \   / ____|  ____|__   __|__   __|_   _| \ | |/ ____|/ ____|
-	# | |  __| |__) | | | | |  | | | (___ | |__     | |     | |    | | |  \| | |  __| (___  
-	# | | |_ |  _  /  | | | |  | |  \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \ 
+	# | |  __| |__) | | | | |  | | | (___ | |__     | |     | |    | | |  \| | |  __| (___
+	# | | |_ |  _  /  | | | |  | |  \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \
 	# | |__| | | \ \ _| |_| |__| |  ____) | |____   | |     | |   _| |_| |\  | |__| |____) |
-	#  \_____|_|  \_\_____|_____/  |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/ 
+	#  \_____|_|  \_\_____|_____/  |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/
 	#
 	def fixedCountRadioButtonClicked(self):
 		self.form.userDefinedGridLinesTextInput.setEnabled(False)
@@ -1876,9 +1876,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		gridItem.gridOffset['units'] = self.form.gridOffsetUnits.currentText()
 
 		return gridItem
-		
 
-	def gridSettingsAddButtonClicked(self):		
+
+	def gridSettingsAddButtonClicked(self):
 		settingsInst = self.getGridItemFromGui()
 
 		#check if all items have same type of coordinate system
@@ -1894,13 +1894,13 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 			#disable/enable grid plane drawing if rectangular, for cylindrical just axis z
 			if settingsInst.coordsType == "rectangular":
-				self.form.auxGridAxis.setEnabled(True)				
+				self.form.auxGridAxis.setEnabled(True)
 			else:
 				#set grid drawing plane to 'z' and disable chosing plane to draw grid
 				index = self.form.auxGridAxis.findText('z', QtCore.Qt.MatchFixedString)
 				if index >= 0:
 					 self.form.auxGridAxis.setCurrentIndex(index)
-				self.form.auxGridAxis.setEnabled(False)				
+				self.form.auxGridAxis.setEnabled(False)
 
 			self.guiHelpers.addSettingsItemGui(settingsInst)	#add item into gui tree views
 			self.guiHelpers.updateMeshPriorityDisableItems()	#update grid priority table at object assignment panel
@@ -1927,8 +1927,8 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.guiHelpers.updateMeshPriorityDisableItems()	#update grid priority table at object assignment panel
 
 	def gridSettingsUpdateButtonClicked(self):
-		### capture UI settings	
-		settingsInst = self.getGridItemFromGui() 
+		### capture UI settings
+		settingsInst = self.getGridItemFromGui()
 
 		### replace old with new settingsInst
 		selectedItems = self.form.gridSettingsTreeView.selectedItems()
@@ -2074,13 +2074,13 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 	#
 	# MATERIAL SETTINGS
-	#  __  __       _______ ______ _____  _____          _         _____ ______ _______ _______ _____ _   _  _____  _____ 
+	#  __  __       _______ ______ _____  _____          _         _____ ______ _______ _______ _____ _   _  _____  _____
 	# |  \/  |   /\|__   __|  ____|  __ \|_   _|   /\   | |       / ____|  ____|__   __|__   __|_   _| \ | |/ ____|/ ____|
-	# | \  / |  /  \  | |  | |__  | |__) | | |    /  \  | |      | (___ | |__     | |     | |    | | |  \| | |  __| (___  
-	# | |\/| | / /\ \ | |  |  __| |  _  /  | |   / /\ \ | |       \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \ 
+	# | \  / |  /  \  | |  | |__  | |__) | | |    /  \  | |      | (___ | |__     | |     | |    | | |  \| | |  __| (___
+	# | |\/| | / /\ \ | |  |  __| |  _  /  | |   / /\ \ | |       \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \
 	# | |  | |/ ____ \| |  | |____| | \ \ _| |_ / ____ \| |____   ____) | |____   | |     | |   _| |_| |\  | |__| |____) |
-	# |_|  |_/_/    \_\_|  |______|_|  \_\_____/_/    \_\______| |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/ 
-	#      
+	# |_|  |_/_/    \_\_|  |______|_|  \_\_____/_/    \_\______| |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/
+	#
 
 	def getMaterialItemFromGui(self):
 		name = self.form.materialSettingsNameInput.text()
@@ -2105,7 +2105,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		materialItem.constants['epsilon'] = epsilon
 		materialItem.constants['mue'] = mue
 		materialItem.constants['kappa'] = kappa
-		materialItem.constants['sigma'] = sigma	
+		materialItem.constants['sigma'] = sigma
 
 		materialItem.constants['conductingSheetThicknessValue'] = conductingSheetThicknessValue
 		materialItem.constants['conductingSheetThicknessUnits'] = conductingSheetThicknessUnits
@@ -2119,8 +2119,8 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			materialItem.type = "conducting sheet"
 
 		return materialItem
-		
-	
+
+
 	def materialSettingsAddButtonClicked(self):
 		materialItem = self.getMaterialItemFromGui()
 
@@ -2140,7 +2140,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 		self.guiHelpers.addSettingsItemGui(materialItem)
 		self.guiSignals.materialsChanged.emit("add")
-			
+
 
 	def materialSettingsRemoveButtonClicked(self):
 		selectedItem = self.form.materialSettingsTreeView.selectedItems()[0]
@@ -2156,7 +2156,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			return
 
 		materialGroupWidgetItems = self.form.objectAssignmentRightTreeWidget.findItems(
-			selectedItem.text(0), 
+			selectedItem.text(0),
 			QtCore.Qt.MatchExactly | QtCore.Qt.MatchFlag.MatchRecursive
 			)
 
@@ -2395,13 +2395,13 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			self.cadHelpers.printError(traceback.format_exc())
 
 	# EXCITATION SETTINGS
-	#  ________   _______ _____ _______    _______ _____ ____  _   _    _____ ______ _______ _______ _____ _   _  _____  _____ 
+	#  ________   _______ _____ _______    _______ _____ ____  _   _    _____ ______ _______ _______ _____ _   _  _____  _____
 	# |  ____\ \ / / ____|_   _|__   __|/\|__   __|_   _/ __ \| \ | |  / ____|  ____|__   __|__   __|_   _| \ | |/ ____|/ ____|
-	# | |__   \ V / |      | |    | |  /  \  | |    | || |  | |  \| | | (___ | |__     | |     | |    | | |  \| | |  __| (___  
-	# |  __|   > <| |      | |    | | / /\ \ | |    | || |  | | . ` |  \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \ 
+	# | |__   \ V / |      | |    | |  /  \  | |    | || |  | |  \| | | (___ | |__     | |     | |    | | |  \| | |  __| (___
+	# |  __|   > <| |      | |    | | / /\ \ | |    | || |  | | . ` |  \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \
 	# | |____ / . \ |____ _| |_   | |/ ____ \| |   _| || |__| | |\  |  ____) | |____   | |     | |   _| |_| |\  | |__| |____) |
-	# |______/_/ \_\_____|_____|  |_/_/    \_\_|  |_____\____/|_| \_| |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/ 
-	#                                                                                                                          
+	# |______/_/ \_\_____|_____|  |_/_/    \_\_|  |_____\____/|_| \_| |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/
+	#
 
 	def getExcitationItemFromGui(self):
 		name = self.form.excitationSettingsNameInput.text()
@@ -2443,9 +2443,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		if (isMoreThanOne):
 			self.guiHelpers.displayMessage("There could be just one excitation!")
 			return
-		
+
 		self.guiHelpers.addSettingsItemGui(settingsInst)
-		
+
 
 	def excitationSettingsRemoveButtonClicked(self):
 		selectedItem = self.form.excitationSettingsTreeView.selectedItems()[0]
@@ -2467,16 +2467,16 @@ class ExportOpenEMSDialog(QtCore.QObject):
 	def excitationSettingsUpdateButtonClicked(self):
 		### capture UI settings
 		settingsInst = self.getExcitationItemFromGui()
-	
+
 		### replace old with new settingsInst
 		selectedItems = self.form.excitationSettingsTreeView.selectedItems()
 		if len(selectedItems) != 1:
 			self.guiHelpers.displayMessage("Excitation ERROR during update.", forceModal=False)
 			return
 		selectedItems[0].setData(0, QtCore.Qt.UserRole, settingsInst)
-		
+
 		### update other UI elements to propagate changes
-		# replace oudated copy of settingsInst 
+		# replace oudated copy of settingsInst
 		self.updateObjectAssignmentRightTreeWidgetItemData("Excitation", selectedItems[0].text(0), settingsInst)
 
 		# emit rename signal
@@ -2486,13 +2486,13 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.guiHelpers.displayMessage("Excitation updated.", forceModal=False)
 
 	# PORT SETTINGS
-	#  _____   ____  _____ _______    _____ ______ _______ _______ _____ _   _  _____  _____ 
+	#  _____   ____  _____ _______    _____ ______ _______ _______ _____ _   _  _____  _____
 	# |  __ \ / __ \|  __ \__   __|  / ____|  ____|__   __|__   __|_   _| \ | |/ ____|/ ____|
-	# | |__) | |  | | |__) | | |    | (___ | |__     | |     | |    | | |  \| | |  __| (___  
-	# |  ___/| |  | |  _  /  | |     \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \ 
+	# | |__) | |  | | |__) | | |    | (___ | |__     | |     | |    | | |  \| | |  __| (___
+	# |  ___/| |  | |  _  /  | |     \___ \|  __|    | |     | |    | | | . ` | | |_ |\___ \
 	# | |    | |__| | | \ \  | |     ____) | |____   | |     | |   _| |_| |\  | |__| |____) |
-	# |_|     \____/|_|  \_\ |_|    |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/ 
-	#    
+	# |_|     \____/|_|  \_\ |_|    |_____/|______|  |_|     |_|  |_____|_| \_|\_____|_____/
+	#
 
 	def getPortItemFromGui(self):
 		name = self.form.portSettingsNameInput.text()
@@ -2673,7 +2673,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 	def portSettingsUpdateButtonClicked(self):
 		### capture UI settings
 		settingsInst = self.getPortItemFromGui()
-	
+
 		### replace old with new settingsInst
 		selectedItems = self.form.portSettingsTreeView.selectedItems()
 		if len(selectedItems) != 1:
@@ -3101,15 +3101,15 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		self.guiHelpers.setComboboxItem(self.form.striplinePortPropagationComboBox, previousPropagationValue)
 
 	#  _     _    _ __  __ _____  ______ _____    _____        _____ _______            _   _   _
-	# | |   | |  | |  \/  |  __ \|  ____|  __ \  |  __ \ /\   |  __ \__   __|          | | | | (_)                
-	# | |   | |  | | \  / | |__) | |__  | |  | | | |__) /  \  | |__) | | |     ___  ___| |_| |_ _ _ __   __ _ ___ 
+	# | |   | |  | |  \/  |  __ \|  ____|  __ \  |  __ \ /\   |  __ \__   __|          | | | | (_)
+	# | |   | |  | | \  / | |__) | |__  | |  | | | |__) /  \  | |__) | | |     ___  ___| |_| |_ _ _ __   __ _ ___
 	# | |   | |  | | |\/| |  ___/|  __| | |  | | |  ___/ /\ \ |  _  /  | |    / __|/ _ \ __| __| | '_ \ / _` / __|
 	# | |___| |__| | |  | | |    | |____| |__| | | |  / ____ \| | \ \  | |    \__ \  __/ |_| |_| | | | | (_| \__ \
 	# |______\____/|_|  |_|_|    |______|_____/  |_| /_/    \_\_|  \_\ |_|    |___/\___|\__|\__|_|_| |_|\__, |___/
-	#                                                                                                    __/ |    
-	#                                                                                                   |___/    
+	#                                                                                                    __/ |
+	#                                                                                                   |___/
 	#
-	
+
 	def getLumpedPartItemFromGui(self):
 		name = self.form.lumpedPartSettingsNameInput.text()
 
@@ -3134,17 +3134,17 @@ class ExportOpenEMSDialog(QtCore.QObject):
 		lumpedPartItem.params['combinationType'] = self.form.lumpedPartCombinationType.currentText()
 
 		return lumpedPartItem
-		
-	
+
+
 	def lumpedPartSettingsAddButtonClicked(self):
 		# capture UI settings
-		settingsInst = self.getLumpedPartItemFromGui()		
+		settingsInst = self.getLumpedPartItemFromGui()
 
 		#check for duplicity in names if there is some warning message displayed
 		isDuplicityName = self.checkTreeWidgetForDuplicityName(self.form.lumpedPartTreeView, settingsInst.name)
 		if (not isDuplicityName):
 			self.guiHelpers.addSettingsItemGui(settingsInst)
-			
+
 
 	def lumpedPartSettingsRemoveButtonClicked(self):
 		selectedItem = self.form.lumpedPartTreeView.selectedItems()[0]
@@ -3168,12 +3168,12 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 		self.form.lumpedPartTreeView.invisibleRootItem().removeChild(selectedItem)
 		lumpedPartGroupItem.parent().removeChild(lumpedPartGroupItem)
-		
+
 
 	def lumpedPartSettingsUpdateButtonClicked(self):
 		### capture UI settings
-		settingsInst = self.getLumpedPartItemFromGui()		
-	
+		settingsInst = self.getLumpedPartItemFromGui()
+
 		### replace old with new settingsInst
 		selectedItems = self.form.lumpedPartTreeView.selectedItems()
 		if len(selectedItems) != 1:
@@ -3195,9 +3195,9 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 	#   _____________   ____________  ___    __       _____ _______________________   _____________
 	#  / ____/ ____/ | / / ____/ __ \/   |  / /      / ___// ____/_  __/_  __/  _/ | / / ____/ ___/
-	# / / __/ __/ /  |/ / __/ / /_/ / /| | / /       \__ \/ __/   / /   / /  / //  |/ / / __ \__ \ 
-	#/ /_/ / /___/ /|  / /___/ _, _/ ___ |/ /___    ___/ / /___  / /   / / _/ // /|  / /_/ /___/ / 
-	#\____/_____/_/ |_/_____/_/ |_/_/  |_/_____/   /____/_____/ /_/   /_/ /___/_/ |_/\____//____/  
+	# / / __/ __/ /  |/ / __/ / /_/ / /| | / /       \__ \/ __/   / /   / /  / //  |/ / / __ \__ \
+	#/ /_/ / /___/ /|  / /___/ _, _/ ___ |/ /___    ___/ / /___  / /   / / _/ // /|  / /_/ /___/ /
+	#\____/_____/_/ |_/_____/_/ |_/_/  |_/_____/   /____/_____/ /_/   /_/ /___/_/ |_/\____//____/
 	#
 	def materialTreeWidgetItemChanged(self, current, previous):
 		print("materialTreeWidgetItemChanged(): Material item changed.")
@@ -3359,14 +3359,14 @@ class ExportOpenEMSDialog(QtCore.QObject):
 			self.form.customExcitationRadioButton.click()
 			self.form.customExcitationTextInput.setText(currSetting.custom['functionStr'])
 			self.form.customExcitationF0NumberInput.setValue(currSetting.custom['f0'])
-			
+
 			index = self.form.excitationUnitsNumberInput.findText(currSetting.units, QtCore.Qt.MatchFixedString)
 			if index >= 0:
 				self.form.excitationUnitsNumberInput.setCurrentIndex(index)
 			pass
 		else:
 			return #no gui update
-			
+
 		index = self.form.excitationUnitsNumberInput.findText(currSetting.units, QtCore.Qt.MatchFixedString)
 		if index >= 0:
 			self.form.excitationUnitsNumberInput.setCurrentIndex(index)
@@ -3599,7 +3599,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 ####################################################################################################################################################################
 # End of PANEL definition
 ####################################################################################################################################################################
- 
+
 if __name__ == "__main__":
 	#
 	#	TODO:
@@ -3609,7 +3609,7 @@ if __name__ == "__main__":
 		"""
 			Finally this is running, it will create Misc tab on right side of View3D and there is button for open
 			addon to specify simulation.
-			
+
 			Found in forum here: https://blenderartists.org/t/parent-pyqt-window-widget-to-blenders-window/700722/17
 			related:			 https://blenderartists.org/t/bqt-custom-ui-for-add-ons-tool-in-blender-with-pyqt-or-pyside/1458808
 		"""

--- a/ExportOpenEMSDialog.py
+++ b/ExportOpenEMSDialog.py
@@ -1,5 +1,5 @@
-from PySide6 import QtGui, QtCore, QtWidgets
-from PySide6.QtCore import Slot
+from PySide import QtGui, QtCore, QtWidgets
+from PySide.QtCore import Slot
 import os, sys
 import re
 import random

--- a/KiCADImporterToolDialog.py
+++ b/KiCADImporterToolDialog.py
@@ -1,5 +1,5 @@
-from PySide2 import QtGui, QtCore, QtWidgets
-from PySide2.QtCore import Slot
+from PySide6 import QtGui, QtCore, QtWidgets
+from PySide6.QtCore import Slot
 import os, sys
 import re
 
@@ -87,7 +87,7 @@ class KiCADImporterToolDialog(QtCore.QObject):
 ####################################################################################################################################################################
 # End of PANEL definition
 ####################################################################################################################################################################
- 
+
 if __name__ == "__main__":
 
 	if APP_CONTEXT in ["FreeCAD"]:

--- a/KiCADImporterToolDialog.py
+++ b/KiCADImporterToolDialog.py
@@ -1,5 +1,5 @@
-from PySide6 import QtGui, QtCore, QtWidgets
-from PySide6.QtCore import Slot
+from PySide import QtGui, QtCore, QtWidgets
+from PySide.QtCore import Slot
 import os, sys
 import re
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,29 @@ To make long story short below is picture already defined simulation in plugin G
 The main purpose of this GUI is to made easy setup simulation and help to define mesh for it. Right meshing is crucial when using FDTD simulation, it has affect on results. There are some help function like displaying defined mesh lines in FreeCAD model, setting priorities for mesh gridlines and make mesh grid setting understandable for normal people.
 
 ![GUI example 1](./documentation_img/GUI_example_1.png)
+
+Installation
+============
+1. Clone this repository in a subfolder of the FreeCAD macros folder. If you don't know where such folder is, open FreeCAD, then *Macro→Macros...→User macros location*. (Windows default Macro directory: `C:\Users\<your_user_name>\AppData\Roaming\FreeCAD\Macro`.)
+2. Copy the `FreeCAD-OpenEMS-Export.FCMacro` file into the FreeCAD macros folder.
+
+Example directory structure after installation:
+```
+/path/to/FreeCAD/Macro
+├── FreeCAD-OpenEMS-Export
+│   ├── documentation
+│   ├── documentation_img
+│   ├── experiments
+│   ├── ExportOpenEMSDialog.py
+│   ├── FreeCAD-OpenEMS-Export.FCMacro
+│   ├── img
+│   ├── __init__.py
+│   ├── KiCADImporterToolDialog.py
+│   ├── LICENSE
+│   ├── README.md
+│   ├── test
+│   ├── ui
+│   ├── utils3rdParty
+│   └── utilsOpenEMS
+└── FreeCAD-OpenEMS-Export.FCMacro
+```

--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@
 #
 
 import bpy
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 from .ExportOpenEMSDialog import *
 
 bl_info = {

--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@
 #
 
 import bpy
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 from .ExportOpenEMSDialog import *
 
 bl_info = {

--- a/test/SimpleTest_1.py
+++ b/test/SimpleTest_1.py
@@ -11,7 +11,7 @@ sys.path.insert(0, parentdir)
 
 
 from ExportOpenEMSDialog import ExportOpenEMSDialog
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 
 if __name__ == '__main__':
     #

--- a/test/SimpleTest_1.py
+++ b/test/SimpleTest_1.py
@@ -11,7 +11,7 @@ sys.path.insert(0, parentdir)
 
 
 from ExportOpenEMSDialog import ExportOpenEMSDialog
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 
 if __name__ == '__main__':
     #

--- a/utilsOpenEMS/GuiHelpers/CadInterface.py
+++ b/utilsOpenEMS/GuiHelpers/CadInterface.py
@@ -1,8 +1,8 @@
 import re
 import os
 
-import PySide6.QtWidgets
-from PySide6 import QtGui, QtCore, QtWidgets, QtUiTools
+import PySide.QtWidgets
+from PySide import QtGui, QtCore, QtWidgets, QtUiTools
 
 class CadInterface:
     def __init__(self, APP_DIR=""):

--- a/utilsOpenEMS/GuiHelpers/CadInterface.py
+++ b/utilsOpenEMS/GuiHelpers/CadInterface.py
@@ -1,8 +1,8 @@
 import re
 import os
 
-import PySide2.QtWidgets
-from PySide2 import QtGui, QtCore, QtWidgets, QtUiTools
+import PySide6.QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets, QtUiTools
 
 class CadInterface:
     def __init__(self, APP_DIR=""):

--- a/utilsOpenEMS/GuiHelpers/FreeCADHelpers.py
+++ b/utilsOpenEMS/GuiHelpers/FreeCADHelpers.py
@@ -1,6 +1,6 @@
 from utilsOpenEMS.GuiHelpers.CadInterface import CadInterface
 
-from PySide2 import QtCore
+from PySide6 import QtCore
 import FreeCAD
 import FreeCADGui
 import Draft

--- a/utilsOpenEMS/GuiHelpers/FreeCADHelpers.py
+++ b/utilsOpenEMS/GuiHelpers/FreeCADHelpers.py
@@ -1,6 +1,6 @@
 from utilsOpenEMS.GuiHelpers.CadInterface import CadInterface
 
-from PySide6 import QtCore
+from PySide import QtCore
 import FreeCAD
 import FreeCADGui
 import Draft

--- a/utilsOpenEMS/GuiHelpers/GuiHelpers.py
+++ b/utilsOpenEMS/GuiHelpers/GuiHelpers.py
@@ -1,4 +1,4 @@
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import re
 import os
 from utilsOpenEMS.GlobalFunctions.GlobalFunctions import _bool, _r

--- a/utilsOpenEMS/GuiHelpers/GuiHelpers.py
+++ b/utilsOpenEMS/GuiHelpers/GuiHelpers.py
@@ -1,4 +1,4 @@
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import re
 import os
 from utilsOpenEMS.GlobalFunctions.GlobalFunctions import _bool, _r

--- a/utilsOpenEMS/GuiHelpers/GuiSignals.py
+++ b/utilsOpenEMS/GuiHelpers/GuiSignals.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, QObject
+from PySide.QtCore import Signal, QObject
 
 class GuiSignals(QObject):
     materialsChanged = Signal(str)

--- a/utilsOpenEMS/GuiHelpers/GuiSignals.py
+++ b/utilsOpenEMS/GuiHelpers/GuiSignals.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import Signal, QObject
+from PySide6.QtCore import Signal, QObject
 
 class GuiSignals(QObject):
     materialsChanged = Signal(str)

--- a/utilsOpenEMS/SaveLoad/IniFile0v1.py
+++ b/utilsOpenEMS/SaveLoad/IniFile0v1.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 
 from utilsOpenEMS.GuiHelpers.GuiSignals import GuiSignals
 

--- a/utilsOpenEMS/SaveLoad/IniFile0v1.py
+++ b/utilsOpenEMS/SaveLoad/IniFile0v1.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 
 from utilsOpenEMS.GuiHelpers.GuiSignals import GuiSignals
 

--- a/utilsOpenEMS/SaveLoad/IniValidator0v1.py
+++ b/utilsOpenEMS/SaveLoad/IniValidator0v1.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 #from utilsOpenEMS.GlobalFunctions.GlobalFunctions import _bool, _r
 
 def _bool(s):

--- a/utilsOpenEMS/SaveLoad/IniValidator0v1.py
+++ b/utilsOpenEMS/SaveLoad/IniValidator0v1.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 #from utilsOpenEMS.GlobalFunctions.GlobalFunctions import _bool, _r
 
 def _bool(s):

--- a/utilsOpenEMS/ScriptLinesGenerator/CommonScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/CommonScriptLinesGenerator.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math

--- a/utilsOpenEMS/ScriptLinesGenerator/CommonScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/CommonScriptLinesGenerator.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math

--- a/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math

--- a/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math
@@ -199,7 +199,7 @@ class OctaveScriptLinesGenerator:
         elif (gridCoordsType == "cylindrical"):
             genScript += "CSX = InitCSX('CoordSystem', 1); % Cylindrical coordinate system.\n"
         else:
-            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"				
+            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"
 
         genScript += "mesh.x = []; % mesh variable initialization (Note: x y z implies type Cartesian).\n"
         genScript += "mesh.y = [];\n"

--- a/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator2.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator2.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math
@@ -62,7 +62,7 @@ class OctaveScriptLinesGenerator2(CommonScriptLinesGenerator):
         elif (gridCoordsType == "cylindrical"):
             genScript += "CSX = InitCSX('CoordSystem', 1); % Cylindrical coordinate system.\n"
         else:
-            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"				
+            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"
 
         genScript += "mesh.x = []; % mesh variable initialization (Note: x y z implies type Cartesian).\n"
         genScript += "mesh.y = [];\n"

--- a/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator2.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/OctaveScriptLinesGenerator2.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import numpy as np
 
 from utilsOpenEMS.GlobalFunctions.GlobalFunctions import _bool, _r

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import numpy as np
 
 from utilsOpenEMS.GlobalFunctions.GlobalFunctions import _bool, _r

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
@@ -688,7 +688,6 @@ class PythonScriptLinesGenerator(OctaveScriptLinesGenerator):
             print("Excitation Settings detected")
             print("#")
             print("#EXCITATION")
-            print('MIERDAAAA')
 
             # FOR WHOLE SIMULATION THERE IS JUST ONE EXCITATION DEFINED, so first is taken!
             if (excitationCategory[0].childCount() > 0):

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator.py
@@ -39,7 +39,7 @@ class PythonScriptLinesGenerator(OctaveScriptLinesGenerator):
         elif (gridCoordsType == "cylindrical"):
             genScript += "CSX = InitCSX('CoordSystem',1); # Cylindrical coordinate system.\n"
         else:
-            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"				
+            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"
         """
         genScript += "FDTD.SetCoordSystem(0) # Cartesian coordinate system.\n"
         genScript += "def mesh():\n"
@@ -688,6 +688,7 @@ class PythonScriptLinesGenerator(OctaveScriptLinesGenerator):
             print("Excitation Settings detected")
             print("#")
             print("#EXCITATION")
+            print('MIERDAAAA')
 
             # FOR WHOLE SIMULATION THERE IS JUST ONE EXCITATION DEFINED, so first is taken!
             if (excitationCategory[0].childCount() > 0):
@@ -736,6 +737,8 @@ class PythonScriptLinesGenerator(OctaveScriptLinesGenerator):
                     genScript += "max_res = 0\n"
                     self.maxGridResolution_m = 0
                     pass
+                elif currSetting.getType() == 'step':
+                    genScript += 'FDTD.SetStepExcite(1)'
                 pass
 
                 genScript += "\n"

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator2.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator2.py
@@ -36,7 +36,7 @@ class PythonScriptLinesGenerator2(CommonScriptLinesGenerator):
         elif (gridCoordsType == "cylindrical"):
             genScript += "CSX = InitCSX('CoordSystem',1); # Cylindrical coordinate system.\n"
         else:
-            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"				
+            genScript += "%%%%%% ERROR GRID COORDINATION SYSTEM TYPE UNKNOWN"
         """
 
         genScript += "def mesh():\n"
@@ -1436,6 +1436,8 @@ class PythonScriptLinesGenerator2(CommonScriptLinesGenerator):
                     genScript += "max_res = 0\n"
                     self.maxGridResolution_m = 0
                     pass
+                elif currSetting.getType() == 'step':
+                    genScript += 'FDTD.SetStepExcite(1)'
                 pass
 
                 genScript += "\n"
@@ -1844,7 +1846,7 @@ title('Frequency: {{}} GHz'.format(nf2ff.freq[0]/1e9))
 legend()
 
 show()
-  
+
 #
 # Dump radiation field to vtk file
 #

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator2.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator2.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math

--- a/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator2.py
+++ b/utilsOpenEMS/ScriptLinesGenerator/PythonScriptLinesGenerator2.py
@@ -2,7 +2,7 @@
 #
 #
 import os
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import numpy as np
 import re
 import math


### PR DESCRIPTION
The macro was failing in FreeCAD 1.0 due to old version of `PySide` hardcoded in the import. As suggested by TheMarkster [here](https://forum.freecad.org/viewtopic.php?p=787258#p787258), I removed the version number in all `from PySide import blah`. Now the macro is working for me in the following two versions:

```
OS: KDE Flatpak runtime (GNOME/gnome)
Word size of FreeCAD: 64-bit
Version: 0.21.0.33639 (Git)
Build type: Release
Branch: (HEAD detached at 1580fe7)
Hash: 1580fe7c9696654803a93da8cf372f75e75149fa
Python 3.10.11, Qt 5.15.10, Coin 4.0.0, Vtk 8.2.0, OCC 7.7.1
Locale: English/United States (en_US)
Installed mods: 
  * ExplodedAssembly
```

```
OS: KDE Flatpak runtime (GNOME/gnome)
Word size of FreeCAD: 64-bit
Version: 1.0.0RC2.38806 (Git)
Build type: Release
Branch: (HEAD detached at 3d63fc6)
Hash: 3d63fc6c2f665a8d5e6468845a419bcac80756c7
Python 3.11.10, Qt 6.7.3, Coin 4.0.3, Vtk 9.2.6, OCC 7.8.1
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: FreeCAD Dark.qss/FreeCAD Dark/
Installed mods: 
  * ExplodedAssembly
```

# Edit
Now I realize there were more commits in this branch, sorry for the mess. In any case, I think all changes are positive.